### PR TITLE
use docker to run the example

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-streams</artifactId>
-            <version>0.10.3.0-SNAPSHOT</version>
+            <version>0.10.2.1</version>
         </dependency>
     </dependencies>
     <build>
@@ -38,6 +38,13 @@
                     </execution>
                 </executions>
                 <configuration>
+                    <shadedArtifactAttached>true</shadedArtifactAttached>
+                    <transformers>
+                        <transformer implementation=
+                                             "org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                            <mainClass>com.shapira.examples.streams.wordcount.WordCountExample</mainClass>
+                        </transformer>
+                    </transformers>
                     <finalName>uber-${artifactId}-${version}</finalName>
                 </configuration>
             </plugin>

--- a/src/main/java/com/shapira/examples/streams/wordcount/WordCountExample.java
+++ b/src/main/java/com/shapira/examples/streams/wordcount/WordCountExample.java
@@ -20,7 +20,7 @@ public class WordCountExample {
 
         Properties props = new Properties();
         props.put(StreamsConfig.APPLICATION_ID_CONFIG, "wordcount");
-        props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, args[0] + ":9092");
         props.put(StreamsConfig.KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
         props.put(StreamsConfig.VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
 
@@ -56,7 +56,7 @@ public class WordCountExample {
 
         // usually the stream application would be running forever,
         // in this example we just let it run for some time and stop since the input data is finite.
-        Thread.sleep(5000L);
+        Thread.sleep(5 * 60 * 1000L); // 5 mins
 
         streams.close();
 


### PR DESCRIPTION
Hi Gwen,

It wasn't easy to run your example (the kafka streams maven dependency could not be found), your uber jar is not runnable, plus I did not want to install Kafka on my mac.

So I ended up using docker for the steps described in the README.md
In the end, despite the length of the command lines, I find it much more easier to run.

This PR addresses these points.

Thanks for your great work and great book.
N.