### PR TITLE
Updated Kafka streams maven version & fixed readme 

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ If you want to reset state and re-run the application (maybe with some changes?)
 
 1. Reset internal topics (used for shuffle and state-stores):
 
-    `bin/kafka-streams-application-reset.sh --application-id wordcount --bootstrap-servers localhost:9092 --input-topic wordcount-input`
+    `bin/kafka-streams-application-reset.sh --application-id wordcount --bootstrap-servers localhost:9092 --input-topics wordcount-input`
 
 2. (optional) Delete the output topic:
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-streams</artifactId>
-            <version>0.10.3.0-SNAPSHOT</version>
+            <version>0.11.0.0</version>
         </dependency>
     </dependencies>
     <build>


### PR DESCRIPTION
used mvn commands to build and package
Verified the change works by following Readme instructions.
```
bin/kafka-console-producer.sh --broker-list localhost:9092 --topic wordcount-input
>hello
>world
>mean
>fancy
>fancier
>forest
>farce
>farther
>far
>farm
>farm
>mean
```

```
bin/kafka-console-consumer.sh --topic wordcount-output --from-beginning --bootstrap-server localhost:9092 --property print.key=true

hello	1
world	1
mean	1
fancy	1
fancier	1
forest	1
farce	1
farther	1
far	1
farm	2
mean	2
```