### PR TITLE
Add "slf4j-simple" dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,11 @@
             <artifactId>kafka-streams</artifactId>
             <version>2.8.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>1.7.21</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>


### PR DESCRIPTION
Fix for "Failed to load class 'org.slf4j.impl.StaticLoggerBinder'" error